### PR TITLE
Stopped deprecation warning by switching Hash#index to #key in parser.rb arg parsing

### DIFF
--- a/lib/choice/parser.rb
+++ b/lib/choice/parser.rb
@@ -105,7 +105,7 @@ module Choice
 
           # Add this value to the choices hash with the key of the option's
           # name.  If we expect an array, tack this argument on.
-          name = hashes['shorts'].index(arg)
+          name = hashes['shorts'].key(arg)
           if arrayed[name]
             choices[name] ||= []
             choices[name] << value unless value.nil?


### PR DESCRIPTION
The following is seen on use

gems/choice-0.1.4/lib/choice/parser.rb:108: warning: Hash#index is deprecated; use Hash#key
