### PR TITLE
Fix separator handling.

### DIFF
--- a/lib/choice/writer.rb
+++ b/lib/choice/writer.rb
@@ -63,7 +63,7 @@ module Choice
         # If the option is a hash, run it through option_line.  Otherwise
         # just print it out as is.
         options.each do |name, option|
-          if option.respond_to?(:to_h)
+          if option and option.respond_to?(:to_h)
             option_line(option.to_h)          
           else
             puts name

--- a/test/test_choice.rb
+++ b/test/test_choice.rb
@@ -80,10 +80,10 @@ class TestChoice < Test::Unit::TestCase
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
-    HELP
+HELP
 
     assert_equal help_string, HELP_STRING
   end
@@ -116,10 +116,10 @@ Usage: choice [-mu]
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
-    HELP
+HELP
 
     assert_equal help_string, UNKNOWN_STRING
   end
@@ -152,10 +152,10 @@ Usage: choice [-mu]
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
-    HELP
+HELP
 
     assert_equal help_string, REQUIRED_STRING
   end
@@ -166,7 +166,7 @@ Usage: choice [-mu]
       header ""
       options :band => { :short => "-b", :long => "--band=BAND", :cast => String, :desc => ["Your favorite band.", "Something cool."],
                          :validate => /\w+/ },
-                         :animal => { :short => "-a", :long => "--animal=ANIMAL", :cast => String, :desc => "Your favorite animal." }
+              :animal => { :short => "-a", :long => "--animal=ANIMAL", :cast => String, :desc => "Your favorite animal." }
 
       footer ""
       footer "--help This message"
@@ -195,7 +195,7 @@ Usage: choice [-mu]
     Choice.options do
       header "Gambling is fun again!  Pick a card and a suit (or two), then see if you win!"
       header ""
-      header "Options:" 
+      header "Options:"
 
       option :suit, :required => true do
         short '-s'


### PR DESCRIPTION
Restore failing tests that were removed in 37b5f0c26abae1b1feb4dad03e6505e4416ecf72.
Correct code to properly detect nil options as indicating that a separator is being specified.
