### PR TITLE
Fixes 1.9.3 compatibility issue with NilClass#to_h.

### DIFF
--- a/lib/choice/writer.rb
+++ b/lib/choice/writer.rb
@@ -63,7 +63,7 @@ module Choice
         # If the option is a hash, run it through option_line.  Otherwise
         # just print it out as is.
         options.each do |name, option|
-          if option.respond_to?(:to_h)
+          if !option.nil? && option.respond_to?(:to_h)
             option_line(option.to_h)          
           else
             puts name

--- a/test/test_choice.rb
+++ b/test/test_choice.rb
@@ -80,8 +80,8 @@ class TestChoice < Test::Unit::TestCase
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
     HELP
 
@@ -116,8 +116,8 @@ Usage: choice [-mu]
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
     HELP
 
@@ -152,8 +152,8 @@ Usage: choice [-mu]
 Usage: choice [-mu]
 
     -m                               Your favorite meal.
-                                     
-                                     
+
+And you eat it with...
     -u, --utencil[=UTENCIL]          Your favorite eating utencil.
     HELP
 


### PR DESCRIPTION
1.9.3(I tested with ruby-1.9.3-p547 specifically) has this behavior:

``` ruby
nil.respond_to? :to_h #=> false
```

2.0.0 and up have the opposite behavior:

``` ruby
nil.respond_to? :to_h #=> true
```

This was in turn causing the output to b incorrect with regard to defined separators.
