### PR TITLE
Option refactoring

### DIFF
--- a/examples/gamble.rb
+++ b/examples/gamble.rb
@@ -12,9 +12,9 @@ cards.merge!('1' => 'ace', '11' => 'jack', '12' => 'queen', '13' => 'king')
 Choice.options do
   header "Gambling is fun again!  Pick a card and a suit (or two), then see if you win!"
   header ""
-  header "Options:" 
-  
-  option :suit, :required => true do
+  header "Options:"
+
+  option :suit, :true do
     short '-s'
     long '--suit *SUITS'
     desc "The suit you wish to choose.  Required.  You can pass in more than one, even."
@@ -24,7 +24,7 @@ Choice.options do
 
   separator ''
 
-  option :card, :required => true do
+  option :card, :true do
     short '-c'
     long '--card CARD'
     desc "The card you wish to gamble on.  Required.  Only one, please."

--- a/lib/choice.rb
+++ b/lib/choice.rb
@@ -53,10 +53,10 @@ module Choice
   end
 
   # Defines an option.
-  def option(opt, options = {}, &block)
+  def option(opt, required = false, &block)
     # Notice: options is maintained as an array of arrays, the first element
     # the option name and the second the option object.
-    @@options << [opt.to_s, Option.new(options, &block)]
+    @@options << [opt.to_s, Option.new(required, &block)]
   end
 
   # Separators are text displayed by --help within the options block.

--- a/lib/choice/option.rb
+++ b/lib/choice/option.rb
@@ -6,17 +6,15 @@ module Choice
     # You can instantiate an option on its own or by passing it a name and
     # a block.  If you give it a block, it will eval() the block and set itself
     # up nicely.
-
     def initialize(required = false, &block)
-      @choices = {}
-
       # If we got a block, eval it and set everything up.
       instance_eval(&block) if block_given?
 
       # Is this option required?
-
-      @choices['required'] = required
+      @required = required
     end
+
+    attr_reader :required
 
     def method_missing(method, *args, &block)
       # Mask NoMethodError
@@ -24,99 +22,89 @@ module Choice
       raise ParseError, "I don't know `#{method}'"
     end
 
-    def required
-      @choices['required']
-    end
-
     def short(value=nil)
-      value_setter('short', value)
-      @choices['short']
+      @short ||= value
     end
 
     def short?
-      @choices['short']
+      @short
     end
 
     def long(value=nil)
-      value_setter('long', value)
-      @choices['long']
+      @long ||= value
     end
 
     def long?
-      @choices['long']
+      @long
     end
 
     def default(value=nil)
-      value_setter('default', value)
-      @choices['default']
+      @default ||= value
     end
 
     def default?
-      @choices['default']
+      @default
     end
 
     def cast(value=nil)
-      value_setter('cast', value)
-      @choices['cast']
+      @cast ||= value
     end
 
     def cast?
-      @choices['cast']
+      @cast
     end
 
     def valid(value=nil)
-      value_setter('valid', value)
-      @choices['valid']
+      @valid ||= value
     end
 
     def valid?
-      @choices['valid']
+      @valid
     end
 
     # TODO: Should this be split into two different validate methods?
     def validate(value=nil, &block)
-      if !value.nil?
-        value_setter('validate', value)
-      elsif !block.nil?
-        block_setter('validate', &block)
-      end
-      @choices['validate']
+      @validate ||= if !value.nil?
+                      value
+                    elsif !block.nil?
+                      block
+                    end
     end
 
     def validate?
-      @choices['validate']
+      @validate
     end
 
     def action(&block)
-      block_setter('action', &block)
-      @choices['action']
+      @action ||= block
     end
 
     def action?
-      @choices['action']
+      @action
     end
 
     def filter(&block)
-      block_setter('filter', &block)
-      @choices['filter']
+      @filter ||= block
     end
 
     def filter?
-      @choices['filter']
+      @filter
     end
 
     # The desc method is slightly special: it stores itself as an array and
     # each subsequent call adds to that array, rather than overwriting it.
     # This is so we can do multi-line descriptions easily.
     def desc(string = nil)
-      return @choices['desc'] if string.nil?
+      return @desc if string.nil?
 
-      @choices['desc'] ||= []
-      @choices['desc'].push(string)
+      @desc ||= []
+      @desc.push(string)
     end
 
     # Simple, desc question method.
-    def desc?() !!@choices['desc'] end
+    def desc?
+      @desc
+    end
 
     # Returns Option converted to an array.
     def to_a
@@ -136,21 +124,18 @@ module Choice
 
     # Returns Option converted to a hash.
     def to_h
-      @choices.dup
-    end
-
-    private
-
-    def value_setter(name, value)
-      if !value.nil?
-        @choices[name] = value
-      end
-    end
-
-    def block_setter(name, &block)
-      if block
-        @choices[name] = block
-      end
+      {
+        "required" => required,
+        "short" => short,
+        "long" => long,
+        "desc" => desc,
+        "default" => default,
+        "filter" => filter,
+        "action" => action,
+        "cast" => cast,
+        "valid" => valid,
+        "validate" => validate
+      }.reject {|k, v| v.nil? }
     end
 
     # In case someone tries to use a method we don't know about in their

--- a/test/test_choice.rb
+++ b/test/test_choice.rb
@@ -131,7 +131,7 @@ And you eat it with...
     Choice.options do
       banner "Usage: choice [-mu]"
       header ""
-      option :meal, :required => true do
+      option :meal, :true do
         short '-m'
         desc 'Your favorite meal.'
       end
@@ -195,9 +195,9 @@ And you eat it with...
     Choice.options do
       header "Gambling is fun again!  Pick a card and a suit (or two), then see if you win!"
       header ""
-      header "Options:" 
+      header "Options:"
 
-      option :suit, :required => true do
+      option :suit, :true do
         short '-s'
         long '--suit *SUITS'
         desc "The suit you wish to choose.  Required.  You can pass in more than one, even."
@@ -207,7 +207,7 @@ And you eat it with...
 
       separator ''
 
-      option :card, :required => true do
+      option :card, :true do
         short '-c'
         long '--card CARD'
         desc "The card you wish to gamble on.  Required.  Only one, please."

--- a/test/test_option.rb
+++ b/test/test_option.rb
@@ -14,7 +14,7 @@ class TestOption < Test::Unit::TestCase
     line_two = "I can add many lines."
     line_three = "There is no limit."
 
-    assert_equal false, @option.desc?
+    refute @option.desc?
 
     @option.desc line_one
     @option.desc line_two
@@ -30,7 +30,7 @@ class TestOption < Test::Unit::TestCase
   def test_choice
     short = "-p"
 
-    assert_equal false, @option.short?
+    refute @option.short?
 
     @option.short short
 
@@ -56,7 +56,7 @@ class TestOption < Test::Unit::TestCase
   end
 
   def test_block_choice
-    assert_equal false, @option.action?
+    refute @option.action?
 
     @option.action do
       1 + 1


### PR DESCRIPTION
Flattened out the Option internals.

Removed almost all code from `#method_missing`. The ParseError might go away, after it gets more thought.
